### PR TITLE
[feat] #14 redis 초기 세팅 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/telepigeon/server/config/RedisConfig.java
+++ b/src/main/java/com/telepigeon/server/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.telepigeon.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    }
+
+    // RedisTemplate 쓸거면 이거 사용
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());        // Key Serializer
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));      // Value Serializer
+
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,7 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #14 


## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- redis 초기 세팅 위해서 RedisConfig 생성

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
- redis 사용할 때 RedisTemplate을 사용해서 가져오거나, CrudRepository를 extend해서 repository로 가져올 수 있는 경우가 있는데, 찾아보니 성능은 RedisTemplate을 사용해서 필요한 로직만 직접 설계하는게 좋고, 편한건 CrudRepository로 쓰는게 좋다고 하더라고요. 둘 중 하나로 통일하려는데 뭐가 좋을까요?
- RedisTemplate 사용할 경우의 repository 예시
```java

@RequiredArgsConstructor
public class RefreshTokenRepository {
    private final RedisTemplate<String, Object> redisTemplate;
    private static final String KEY = "refreshToken";
    private String genKey(Long personId){
        return KEY + ":" + personId;
    }
    public void save(String refreshToken, Long personId){
        String key = genKey(personId);
        redisTemplate.opsForValue().set(key, refreshToken);
        redisTemplate.expire(key, 7, TimeUnit.DAYS);
    }
    public String findByPersonId(Long personId){
        String key = genKey(personId);
        return (String) redisTemplate.opsForValue().get(key);
    }
    public void delete(Long personId){
        String key = genKey(personId);
        redisTemplate.delete(key);
    }
    public boolean existsByPersonId(Long personId) {
        String key = genKey(personId);
        return redisTemplate.hasKey(key);
    }
    public void update(String newRefreshToken, Long personId){
        String key = genKey(personId);
        redisTemplate.opsForValue().set(key, newRefreshToken);
        redisTemplate.expire(key, 7, TimeUnit.DAYS);
    }
}
```
- CrudRepository 사용할 경우는 평소 repository사용하는거와 동일(다만 redisTemplate과 달리 도메인을 생성해줘야 함)